### PR TITLE
split fallbackScheme area for layout update ajax request

### DIFF
--- a/app/code/local/Aoe/DesignFallback/Model/Design/Package.php
+++ b/app/code/local/Aoe/DesignFallback/Model/Design/Package.php
@@ -10,6 +10,7 @@ class Aoe_DesignFallback_Model_Design_Package extends Mage_Core_Model_Design_Pac
      * @var array
      */
     static $_fallbackScheme = null;
+    private $_areas = array('frontend', 'adminhtml');
 
     /**
      * Check for files existence by specified scheme
@@ -45,34 +46,37 @@ class Aoe_DesignFallback_Model_Design_Package extends Mage_Core_Model_Design_Pac
             $fallbackConfiguration = $model->getValue();
 
             self::$_fallbackScheme = array();
-            foreach ($fallbackConfiguration as $item) {
-                $packageName = $this->_resolveConfiguration($item['package']);
-                if (!empty($packageName)) { // empty values will be evaluated to current package ...
-                    if (!$this->designPackageExists($packageName, $this->getArea())) {
-                        $packageName = Mage_Core_Model_Design_Package::DEFAULT_PACKAGE;
+            foreach ($this->_areas as $_area) {
+                foreach ($fallbackConfiguration as $item) {
+                    $packageName = $this->_resolveConfiguration($item['package']);
+                    if (!empty($packageName)) { // empty values will be evaluated to current package ...
+                        if (!$this->designPackageExists($packageName, $_area)) {
+                            $packageName = Mage_Core_Model_Design_Package::DEFAULT_PACKAGE;
+                        }
+                    } else {
+                        $packageName = $defaults['_package'];
                     }
-                } else {
-                    $packageName = $defaults['_package'];
-                }
 
-                $themeName = $this->_resolveConfiguration($item['theme']);
-                if (empty($themeName)) {
-                    $themeName = $defaults['_theme'];
-                }
+                    $themeName = $this->_resolveConfiguration($item['theme']);
+                    if (empty($themeName)) {
+                        $themeName = $defaults['_theme'];
+                    }
 
-                $params = array(
-                    '_package' => $packageName,
-                    '_theme'   => $themeName,
-                );
+                    $params = array(
+                        '_package' => $packageName,
+                        '_theme' => $themeName,
+                    );
 
-                // avoid exact duplicates that are neighbours
-                if ($params !== end(self::$_fallbackScheme)) {
-                    self::$_fallbackScheme[] = $params;
+                    // avoid exact duplicates that are neighbours
+                    if ($params !== end(self::$_fallbackScheme)) {
+                        self::$_fallbackScheme[$_area][] = $params;
+                    }
                 }
             }
         }
+        $currentArea = isset($defaults['_area']) ? $defaults['_area'] : $this->getArea();
 
-        return self::$_fallbackScheme;
+        return self::$_fallbackScheme[$currentArea];
     }
 
     /**

--- a/app/code/local/Aoe/DesignFallback/Model/Design/Package.php
+++ b/app/code/local/Aoe/DesignFallback/Model/Design/Package.php
@@ -74,7 +74,7 @@ class Aoe_DesignFallback_Model_Design_Package extends Mage_Core_Model_Design_Pac
                 }
             }
         }
-        $currentArea = isset($defaults['_area']) ? $defaults['_area'] : $this->getArea();
+        $currentArea = isset($defaults['_area']) && !in_array($defaults['_area'], array('header', 'footer')) ? $defaults['_area'] : $this->getArea();
 
         return self::$_fallbackScheme[$currentArea];
     }

--- a/app/code/local/Aoe/DesignFallback/Model/Design/Package.php
+++ b/app/code/local/Aoe/DesignFallback/Model/Design/Package.php
@@ -73,6 +73,21 @@ class Aoe_DesignFallback_Model_Design_Package extends Mage_Core_Model_Design_Pac
                     }
                 }
             }
+
+            if ($defaults && isset($defaults['_area']) && $defaults['_area'] == 'frontend') {
+                $addDesignChangeToFallback = true;
+                foreach (self::$_fallbackScheme['frontend'] as $item) {
+                    if ($item['_package'] == $defaults['_package'] && $item['_theme'] == $defaults['_theme']) {
+                        $addDesignChangeToFallback = false;
+                    }
+                }
+                if ($addDesignChangeToFallback) {
+                    array_unshift(self::$_fallbackScheme['frontend'], [
+                        '_package' => $defaults['_package'],
+                        '_theme' => $defaults['_theme']
+                    ]);
+                }
+            }
         }
         $currentArea = isset($defaults['_area']) && !in_array($defaults['_area'], array('header', 'footer')) ? $defaults['_area'] : $this->getArea();
 


### PR DESCRIPTION
Hello,
On the widget instances, when I try to insert the widget into new block from layout update, magento sends an Ajax request to get all frontend blocks, to generate the reference block select inputs.
In this case the property _fallbackScheme on Aoe_DesignFallback_Model_Design_Package is already defined and instantiated with adminhtml area.
I've split the areas on fallbackscheme to get the correct scheme by the requested area.
hope I was helpful.
